### PR TITLE
Create .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+phylo-env
+__pycache__
+.dockerignore
+.ipynb_checkpoints


### PR DESCRIPTION
Add .dockerignore file:
- This enables docker to ignore certain kinds of files while building a container.
- Makes the repo a bit light weight.